### PR TITLE
Hotfix Vocdoni zkcensus ceremony ascii

### DIFF
--- a/inputs/census.circom
+++ b/inputs/census.circom
@@ -7,9 +7,9 @@ include "/node_modules/circomlib/circuits/smt/smtverifier.circom";
 /**
                                                    ┌───────────┐
                               ┌────────────────────▶lessOrEqual├──────────┐
-       (pub) voteWeight───────┘                    └─────▲─────┘          │
+      (priv) voteWeight───────┘                    └─────▲─────┘          │
                                                          │                │
- (priv) availableWeight─┬────────────────────────────────┘                │
+  (pub) availableWeight─┬────────────────────────────────┘                │
                         │                                                 │    ┌────┐
                         │                                                 └───▶│    └┐
                         │       ┌────────────────────┐                 ┌──────▶│     └┐


### PR DESCRIPTION

hotfix ASCII diagram of circom circuit
    
    the diagram incorrectly described voteWeight as a public signal,
    and availableWeight as a private signal,
    while in fact, voteWeight is a private signal, and availableWeight is public,
    due to how `component main { public }` is defined at the end of the file
    
    Although the ASCII diagram is just human documentation, fix it to avoid confusion


also, Publish results/census_proving_key.zkey (out of LFS)